### PR TITLE
Disable webpacks eval codes

### DIFF
--- a/src/webpack-config.js
+++ b/src/webpack-config.js
@@ -199,11 +199,10 @@ module.exports = function webpackConfig ({
     }))
   }
 
-  // Disable webpacks usage of eval by disabling nodes global
+  // Disable webpacks usage of eval & function string constructor
   // @url https://github.com/webpack/webpack/blob/master/buildin/global.js
-  config.node = {
-    global: false
-  }
+  config.node = false
+
   // In order to still be able to use global we use window instead
   config.plugins.push(
     new webpack.ProvidePlugin({


### PR DESCRIPTION
Firefox webstore csp policy prohibits the use of `eval('')` or `new Function('')`.

Since we have webpacks [node mode](https://webpack.js.org/configuration/node/) enabled, webpack does some optimizations in order to allow to run this code in a node context. We actually don't need this feature since webextensions are not isomorph. If we disabled this feature the bundle size will decrease.

STATUS: Ready
RELATED ISSUE: https://github.com/webextension-toolbox/webextension-toolbox/pull/34