### PR TITLE
Prevent a webpage document element to be detected as the Extension API object when running in content scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "copy-webpack-plugin": "^4.5.1",
     "find-up": "^3.0.0",
     "string-replace-loader": "^2.1.1",
-    "webextension-polyfill": "^0.3.0",
+    "webextension-polyfill": "0.3.0",
     "webpack": "^4.12.0",
     "webpack-watched-glob-entries-plugin": "^2.1.2",
     "webpack-webextension-plugin": "^0.1.1",

--- a/src/webpack-config.js
+++ b/src/webpack-config.js
@@ -128,7 +128,7 @@ module.exports = function webpackConfig ({
       loader: require.resolve('string-replace-loader'),
       query: {
         search: 'typeof browser === "undefined"',
-        replace: 'typeof window.browser === "undefined"'
+        replace: 'typeof window.browser === "undefined" || Object.getPrototypeOf(window.browser) !== Object.prototype'
       }
     })
   }


### PR DESCRIPTION
Browsers have this strange behaviour, that element id references are global on the window object:

```html
<div id="browser"></div>
```

```js
console.log('browser' in window)
```

Normally a contentscript gets its own isolated window object. But not in the case above.

Thanks to @Rob--W we are now aware of this. Until https://github.com/mozilla/webextension-polyfill got patched we need to fix this in our code base.

More info: https://github.com/mozilla/webextension-polyfill/pull/153