### PR TITLE
Apply webextension polyfill for edge platform

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ If you want to get started quickly check out the [yeoman generator](https://gith
 # Browser Support
 * `chrome` (auto [polyfilled](https://github.com/mozilla/webextension-polyfill))
 * `opera` (auto [polyfilled](https://github.com/mozilla/webextension-polyfill))
+* `edge` (auto [polyfilled](https://github.com/mozilla/webextension-polyfill))
 * `firefox`
-* `edge`
 # Features
 ## react.js
 Works with react.js out of the box!  
@@ -61,7 +61,7 @@ else it compiles to:
 
 ## polyfill
   
-The [webextension standard](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions) is currently only supported by firefox and edge. This toolbox adds the necessary polyfills for chrome and opera. 
+The [webextension standard](https://developer.mozilla.org/docs/Mozilla/Add-ons/WebExtensions) is currently only supported by firefox. This toolbox adds the necessary polyfills for chrome and opera. 
 
 This way many webextension apis will work in chrome and opera out of the box. 
   
@@ -98,18 +98,6 @@ $ webextension-toolbox dev chrome
 $ webextension-toolbox dev firefox
 $ webextension-toolbox dev opera
 $ webextension-toolbox dev edge
-```
-
-Note: For Microsoft Edge, it is not allowed to connect to localhost with WebSocket.
-You need to disable "Include all local (intranet) sites not listed in other zones" under "Internet options":
-![GIF Animation showing a cursor turning off Include all local (intranet) sites not listed in other zones option under Internet properties, Security, Local intranet](https://i.imgur.com/puhk4gZ.gif)
-
-or using Registry Editor (regedit):
-```
-Windows Registry Editor Version 5.00
-
-[HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Internet Settings\ZoneMap]
-"IntranetName"=dword:00000000
 ```
 
 ## Build

--- a/src/webpack-config.js
+++ b/src/webpack-config.js
@@ -118,7 +118,7 @@ module.exports = function webpackConfig ({
   config.plugins.push(new GlobEntriesPlugin())
 
   // Add webextension polyfill
-  if (['chrome', 'opera'].includes(vendor)) {
+  if (['chrome', 'opera', 'edge'].includes(vendor)) {
     config.plugins.push(
       new webpack.ProvidePlugin({
         browser: require.resolve('webextension-polyfill')


### PR DESCRIPTION
Since Microsoft Edge version 79 they use Chromium based components.
This means that Edge also needs the webextension polyfill now.

fixes #271

---

I've tested this change locally for my project and it fixes the issue.