### PR TITLE
feat: use browserslist config

### DIFF
--- a/src/common/webpack.ts
+++ b/src/common/webpack.ts
@@ -26,10 +26,26 @@ const { getEntries } = GlobEntriesPlugin;
  * @param {integer} n
  * @param {string} vendor
  * @return {string} version
+ * @deprecated in favor of `getBrowserslistQuery()`
  */
 function getLastNVendorVersion(n: number, vendor: string): string | undefined {
   const { released } = browserslistData[vendor] ?? { released: [] };
   return released[released.length - n] ?? undefined;
+}
+
+/**
+ * Returns a Browserslist query string
+ * for the target vendor and version
+ * @param {string} vendor
+ * @param {string} [version]
+ * @return {string}
+ */
+function getBrowserslistQuery(vendor: string, version?: string): string {
+  if (version && !isNaN(Number(version))) {
+    return `${vendor} ${version}`;
+  }
+
+  return `browserslist config and ${vendor} > 0 or defaults`;
 }
 
 function getExtensionFileType(vendor: string): string {
@@ -68,6 +84,7 @@ export default async function webpackConfig({
   devtool = false,
   minimize = false,
   vendor = "chrome",
+  vendorVersion = "",
   manifestValidation = true,
   port = 35729,
   autoReload = false,
@@ -157,9 +174,8 @@ export default async function webpackConfig({
         loader: "swc-loader",
         options: {
           env: {
-            targets: {
-              [vendor]: getLastNVendorVersion(3, vendor),
-            },
+            // Restrict to vendor by explicit vendor version OR configured browser(s) using browserslist
+            targets: getBrowserslistQuery(vendor, vendorVersion),
           },
           minify: minimize,
         },
@@ -183,10 +199,8 @@ export default async function webpackConfig({
               {
                 // Do not transform modules to CJS
                 modules: false,
-                // Restrict to vendor
-                targets: {
-                  [vendor]: getLastNVendorVersion(3, vendor),
-                },
+                // Restrict to vendor by explicit vendor version OR configured browser(s) using browserslist
+                targets: getBrowserslistQuery(vendor, vendorVersion),
               },
             ],
           ],

--- a/src/common/webpack.ts
+++ b/src/common/webpack.ts
@@ -21,19 +21,6 @@ const { green } = new Chalk();
 const { getEntries } = GlobEntriesPlugin;
 
 /**
- * Returns last n
- * vendor version
- * @param {integer} n
- * @param {string} vendor
- * @return {string} version
- * @deprecated in favor of `getBrowserslistQuery()`
- */
-function getLastNVendorVersion(n: number, vendor: string): string | undefined {
-  const { released } = browserslistData[vendor] ?? { released: [] };
-  return released[released.length - n] ?? undefined;
-}
-
-/**
  * Returns a Browserslist query string
  * for the target vendor and version
  * @param {string} vendor
@@ -41,7 +28,7 @@ function getLastNVendorVersion(n: number, vendor: string): string | undefined {
  * @return {string}
  */
 function getBrowserslistQuery(vendor: string, version?: string): string {
-  if (version && !isNaN(Number(version))) {
+  if (version && !Number.isNaN(Number(version))) {
     return `${vendor} ${version}`;
   }
 


### PR DESCRIPTION
Closes #864

Configures the `swc-loader` and `babel-loader` (via `@babel/preset-env` preset) to target browsers defined by the project's [`browserslist`](https://github.com/browserslist/browserslist#readme) configuration settings, ***but only when the vendor version is NOT explicitly defined***.

If a vendor version is defined (via the `--vendor-version` command line option, or in the saved `.webextensiontoolboxrc` config file), it is used instead of any/all `browserslist` configurations.

If the vendor version is NOT defined and `browserslist` is also NOT configured for the package, the `browserslist` "defaults" are used, which is `> 0.5%, last 2 versions, Firefox ESR, not dead`

Note that this behavior isn't *exactly* backwards compatible, since the defaults (without any configuration at all) target the last 2 versions of all browsers. However, the generated packages **should** work in the same browsers as the current/previous way of handling browser support during compilation/transpilation (i.e. with this change, the default options will provide the same, if not better, browser support).