### PR TITLE
Fix overwriting compiled manifest

### DIFF
--- a/src/common/webpack.ts
+++ b/src/common/webpack.ts
@@ -137,8 +137,10 @@ export default async function webpackConfig({
     path: resolvedTarget,
     filename: "[name].js",
     chunkFilename: "[id].chunk.js",
+    // https://github.com/webpack/webpack-dev-middleware/issues/861
     clean: true,
   };
+
   /** *************************** */
   /*    WEBPACK.OPTIMIZATION    */
   /** *************************** */
@@ -241,6 +243,9 @@ export default async function webpackConfig({
     ignore: compileIgnoredArray,
   });
 
+  // Add manifest to compiled files list
+  compiledFiles.push(resolve(src, "manifest.json"));
+
   // Copy non compiled files
   config.plugins.push(
     new CopyPlugin({
@@ -251,7 +256,7 @@ export default async function webpackConfig({
           context: resolve(src),
           from: resolve(src, "**/*").replace(/\\/g, "/"),
           globOptions: {
-            ignore: [...copyIgnore, "manifest.json", ...compiledFiles],
+            ignore: [...copyIgnore, ...compiledFiles],
           },
           to: resolvedTarget,
         },

--- a/src/common/webpack.ts
+++ b/src/common/webpack.ts
@@ -239,7 +239,7 @@ export default async function webpackConfig({
     })
   );
 
-  let compiledFiles = await glob(resolve(src, defaultGlob), {
+  const compiledFiles = await glob(resolve(src, defaultGlob), {
     ignore: compileIgnoredArray,
   });
 

--- a/src/common/webpack.ts
+++ b/src/common/webpack.ts
@@ -239,7 +239,7 @@ export default async function webpackConfig({
     })
   );
 
-  const compiledFiles = await glob(resolve(src, defaultGlob), {
+  let compiledFiles = await glob(resolve(src, defaultGlob), {
     ignore: compileIgnoredArray,
   });
 


### PR DESCRIPTION
Fixes issue [628](https://github.com/webextension-toolbox/webpack-webextension-plugin/issues/628) in webpack-webextension-plugin

The CopyPlugin copies over the original `manifest.json`, overwriting the compiled version on all recompiles in dev/watch mode.