### PR TITLE
Add missing dev compile option. Update copy-webpack-plugin to ignore manifest.json

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -11,6 +11,7 @@ export default async function build(
   const compiler = await compile({
     vendor,
     devtool: options.devtool,
+    dev: false,
     src: options.src,
     target: options.target,
     minimize: options.minimize,

--- a/src/commands/dev.ts
+++ b/src/commands/dev.ts
@@ -10,6 +10,7 @@ export default async function dev(vendor: string, options: DevCompileOptions) {
   const compiler = await compile({
     vendor,
     devtool: options.devtool,
+    dev: true,
     src: options.src,
     minimize: false,
     target: options.target,

--- a/src/common/webpack.ts
+++ b/src/common/webpack.ts
@@ -251,7 +251,7 @@ export default async function webpackConfig({
           context: resolve(src),
           from: resolve(src, "**/*").replace(/\\/g, "/"),
           globOptions: {
-            ignore: [...copyIgnore, "manifest.json", ...compiledFiles],
+            ignore: [...copyIgnore, "**/manifest.json", ...compiledFiles],
           },
           to: resolvedTarget,
         },


### PR DESCRIPTION
- Fix issue https://github.com/webextension-toolbox/webextension-toolbox/issues/882 

- Fix issue  https://github.com/webextension-toolbox/webpack-webextension-plugin/issues/628